### PR TITLE
feat: wlroots use_win32_vk_code support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,12 +72,38 @@ jobs:
         with:
           go-version: 'stable'
 
+      - name: Resolve MaaFramework Release
+        id: resolve_maa_release
+        uses: actions/github-script@v9
+        env:
+          TARGET_REPOSITORY: MaaXYZ/MaaFramework
+        with:
+          result-encoding: string
+          script: |
+            const repository = process.env.TARGET_REPOSITORY
+            const [owner, repo] = repository.split('/')
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner,
+              repo,
+              per_page: 100,
+            })
+
+            const latestRelease = releases.find(release => !release.draft)
+            if (!latestRelease) {
+              core.setFailed(`No published release found for ${repository}`)
+              return ''
+            }
+
+            core.info(
+              `Resolved MaaFramework release: ${latestRelease.tag_name} (prerelease=${latestRelease.prerelease})`
+            )
+            return latestRelease.tag_name
+
       - name: Download MaaFramework
         uses: robinraju/release-downloader@v1
         with:
           repository: MaaXYZ/MaaFramework
-          latest: true
-          preRelease: true
+          tag: ${{ steps.resolve_maa_release.outputs.result }}
           fileName: "${{ env.MAA_FILE_PREFIX }}-${{ env.ARCH }}*"
           out-file-path: "deps"
           extract: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,9 @@
 **移除构造函数**：`NewCarouselImageController` 已移除。若仅需空操作控制器，请使用 `NewBlankController()`；若需基于录制数据回放，请使用 `NewReplayController(recordingPath)`，录制入口为 `NewRecordController(inner, recordingPath)`。
 **新增**：`SetScreenshot(opts ...ScreenshotOption) error` 与配套选项函数；新增 `WithScreenshotResizeMethod(...)` / `ScreenshotResizeMethod*` 常量，以及 `SetMouseLockFollow(enabled bool) error`
 **新增控制器构造函数**：`NewMacOSController(...)`、`NewAndroidNativeController(...)`、`NewReplayController(...)`、`NewRecordController(...)`
-**接口变更**：`CustomController` 接口新增 `RelativeMove(dx, dy int32) bool`、`Shell(cmd string, timeout int64) (string, bool)`、`GetInfo() (string, bool)` 必须实现方法。已有实现若无需支持，可返回 no-op 成功值
+**接口变更**：
+- `CustomController` 接口新增 `RelativeMove(dx, dy int32) bool`、`Shell(cmd string, timeout int64) (string, bool)`、`GetInfo() (string, bool)` 必须实现方法。已有实现若无需支持，可返回 no-op 成功值
+- WlRoots 支持将按键视为 Win32 VK 键码：`NewWlRootsController(wlrSocketPath string, useWin32VkCode bool)`
 **Win32 InputMethod 命名对齐**：
 - `InputSendMessageWithCursorPosAndBlockInput` → `InputSendMessageWithWindowPos`
 - `InputPostMessageWithCursorPosAndBlockInput` → `InputPostMessageWithWindowPos`

--- a/controller.go
+++ b/controller.go
@@ -97,8 +97,9 @@ func NewWin32Controller(
 // NewWlRootsController creates a WlRoots controller instance.
 func NewWlRootsController(
 	wlrSocketPath string,
+	useWin32VkCode bool,
 ) (*Controller, error) {
-	handle := native.MaaWlRootsControllerCreate(wlrSocketPath)
+	handle := native.MaaWlRootsControllerCreate(wlrSocketPath, useWin32VkCode)
 	if handle == 0 {
 		return nil, errors.New("failed to create WlRoots controller")
 	}

--- a/internal/native/framework.go
+++ b/internal/native/framework.go
@@ -217,7 +217,7 @@ var (
 	MaaAdbControllerCreate           func(adbPath, address string, screencapMethods uint64, inputMethods uint64, config, agentPath string) uintptr
 	MaaPlayCoverControllerCreate     func(address, uuid string) uintptr
 	MaaWin32ControllerCreate         func(hWnd unsafe.Pointer, screencapMethods uint64, mouseMethod, keyboardMethod uint64) uintptr
-	MaaWlRootsControllerCreate       func(wlrSocketPath string) uintptr
+	MaaWlRootsControllerCreate       func(wlrSocketPath string, useWin32VkCode bool) uintptr
 	MaaCustomControllerCreate        func(controller unsafe.Pointer, controllerArg uintptr) uintptr
 	MaaGamepadControllerCreate       func(hWnd unsafe.Pointer, gamepadType MaaGamepadType, screencapMethod uint64) uintptr
 	MaaMacOSControllerCreate         func(windowID uint32, screencapMethod MaaMacOSScreencapMethod, inputMethod MaaMacOSInputMethod) uintptr


### PR DESCRIPTION
[MaaXYZ/MaaFramework#1283](https://github.com/MaaXYZ/MaaFramework/pull/1283)

## Summary by Sourcery

为 WlRoots 控制器新增可选的 Win32 虚拟键码支持，并更新构造函数接口文档。

New Features:
- 通过新的构造函数选项，允许 WlRoots 控制器将按键事件视为 Win32 虚拟键码进行处理。

Enhancements:
- 扩展 WlRoots 控制器创建 API 和原生绑定接口，使其接受 `useWin32VkCode` 标志。
- 更新变更日志，说明新增的 WlRoots Win32 虚拟键码支持以及构造函数签名的变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional Win32 virtual key code support to the WlRoots controller and document the updated constructor interface.

New Features:
- Allow WlRoots controllers to treat key events as Win32 virtual key codes via a new constructor option.

Enhancements:
- Extend the WlRoots controller creation API and native binding to accept a useWin32VkCode flag.
- Update the changelog to describe the new WlRoots Win32 virtual key code support and constructor signature change.

</details>

新功能：
- 在创建 WlRoots 控制器时引入 `useWin32VkCode` 标志，以便可选地将按键事件视作 Win32 虚拟键码。

增强内容：
- 扩展原生 WlRoots 控制器创建绑定，以接受新的 `useWin32VkCode` 选项。
- 更新变更日志，在现有控制器接口变更的说明中，加入新的 WlRoots Win32 VK 键码支持的描述。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 WlRoots 控制器新增可选的 Win32 虚拟键码支持，并更新构造函数接口文档。

New Features:
- 通过新的构造函数选项，允许 WlRoots 控制器将按键事件视为 Win32 虚拟键码进行处理。

Enhancements:
- 扩展 WlRoots 控制器创建 API 和原生绑定接口，使其接受 `useWin32VkCode` 标志。
- 更新变更日志，说明新增的 WlRoots Win32 虚拟键码支持以及构造函数签名的变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional Win32 virtual key code support to the WlRoots controller and document the updated constructor interface.

New Features:
- Allow WlRoots controllers to treat key events as Win32 virtual key codes via a new constructor option.

Enhancements:
- Extend the WlRoots controller creation API and native binding to accept a useWin32VkCode flag.
- Update the changelog to describe the new WlRoots Win32 virtual key code support and constructor signature change.

</details>

</details>