### PR TITLE
feat:add Kwin controller init

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -111,16 +111,18 @@ func NewWlRootsController(
 	}, nil
 }
 
-// NewKWinController creates a KWin / Linux Wayland controller instance.
-
-// deviceNode: The uinput device node path (e.g., "/dev/uinput").
-// screenWidth: The screen width in pixels.
-// screenHeight: The screen height in pixels.
-// useWin32VkCode: If true, key codes passed to click_key / key_down / key_up are
-// interpreted as Win32 Virtual-Key codes (VK_*) and translated to Linux evdev codes
-// internally. If false, key codes are passed through as raw evdev codes.
+// NewKWinController creates a KWin / Linux Wayland controller via PipeWire and /dev/uinput.
 //
-
+// Despite the name "KWin", this controller works with any Wayland compositor that
+// implements the XDG Screencast Portal and kernel has uinput support (e.g., GNOME).
+//
+// deviceNode is the uinput device node path (e.g., "/dev/uinput").
+// screenWidth and screenHeight are the screen dimensions in pixels.
+// useWin32VkCode specifies whether key codes are interpreted as Win32 Virtual-Key codes
+// (VK_*) and translated to Linux evdev codes internally. If false, key codes are passed
+// through as raw evdev codes.
+//
+// Dependencies: pipewire (1.0+), xdg-desktop-portal.
 func NewKWinController(
 	deviceNode string,
 	screenWidth, screenHeight int32,

--- a/controller.go
+++ b/controller.go
@@ -125,7 +125,7 @@ func NewWlRootsController(
 // Dependencies: pipewire (1.0+), xdg-desktop-portal.
 func NewKWinController(
 	deviceNode string,
-	screenWidth, screenHeight int32,
+	screenWidth, screenHeight int,
 	useWin32VkCode bool,
 ) (*Controller, error) {
 	handle := native.MaaKWinControllerCreate(deviceNode, screenWidth, screenHeight, useWin32VkCode)

--- a/controller.go
+++ b/controller.go
@@ -111,6 +111,33 @@ func NewWlRootsController(
 	}, nil
 }
 
+// NewKWinController creates a KWin / Linux Wayland controller instance.
+
+// deviceNode: The uinput device node path (e.g., "/dev/uinput").
+// screenWidth: The screen width in pixels.
+// screenHeight: The screen height in pixels.
+// useWin32VkCode: If true, key codes passed to click_key / key_down / key_up are
+// interpreted as Win32 Virtual-Key codes (VK_*) and translated to Linux evdev codes
+// internally. If false, key codes are passed through as raw evdev codes.
+//
+
+func NewKWinController(
+	deviceNode string,
+	screenWidth, screenHeight int32,
+	useWin32VkCode bool,
+) (*Controller, error) {
+	handle := native.MaaKWinControllerCreate(deviceNode, screenWidth, screenHeight, useWin32VkCode)
+	if handle == 0 {
+		return nil, errors.New("failed to create KWin controller")
+	}
+
+	initControllerStore(handle)
+
+	return &Controller{
+		handle: handle,
+	}, nil
+}
+
 // NewMacOSController creates a macOS controller for native macOS applications.
 // windowID is the CGWindowID of the target window (0 for desktop).
 // screencapMethod is the macOS screencap method to use.

--- a/internal/native/framework.go
+++ b/internal/native/framework.go
@@ -218,7 +218,7 @@ var (
 	MaaPlayCoverControllerCreate     func(address, uuid string) uintptr
 	MaaWin32ControllerCreate         func(hWnd unsafe.Pointer, screencapMethods uint64, mouseMethod, keyboardMethod uint64) uintptr
 	MaaWlRootsControllerCreate       func(wlrSocketPath string, useWin32VkCode bool) uintptr
-	MaaKWinControllerCreate          func(deviceNode string, screenWidth, screenHeight int32, useWin32VkCode bool) uintptr
+	MaaKWinControllerCreate          func(deviceNode string, screenWidth, screenHeight int, useWin32VkCode bool) uintptr
 	MaaCustomControllerCreate        func(controller unsafe.Pointer, controllerArg uintptr) uintptr
 	MaaGamepadControllerCreate       func(hWnd unsafe.Pointer, gamepadType MaaGamepadType, screencapMethod uint64) uintptr
 	MaaMacOSControllerCreate         func(windowID uint32, screencapMethod MaaMacOSScreencapMethod, inputMethod MaaMacOSInputMethod) uintptr

--- a/internal/native/framework.go
+++ b/internal/native/framework.go
@@ -218,6 +218,7 @@ var (
 	MaaPlayCoverControllerCreate     func(address, uuid string) uintptr
 	MaaWin32ControllerCreate         func(hWnd unsafe.Pointer, screencapMethods uint64, mouseMethod, keyboardMethod uint64) uintptr
 	MaaWlRootsControllerCreate       func(wlrSocketPath string, useWin32VkCode bool) uintptr
+	MaaKWinControllerCreate          func(deviceNode string, screenWidth, screenHeight int32, useWin32VkCode bool) uintptr
 	MaaCustomControllerCreate        func(controller unsafe.Pointer, controllerArg uintptr) uintptr
 	MaaGamepadControllerCreate       func(hWnd unsafe.Pointer, gamepadType MaaGamepadType, screencapMethod uint64) uintptr
 	MaaMacOSControllerCreate         func(windowID uint32, screencapMethod MaaMacOSScreencapMethod, inputMethod MaaMacOSInputMethod) uintptr
@@ -447,6 +448,7 @@ var frameworkEntries = []Entry{
 	{&MaaPlayCoverControllerCreate, "MaaPlayCoverControllerCreate"},
 	{&MaaWin32ControllerCreate, "MaaWin32ControllerCreate"},
 	{&MaaWlRootsControllerCreate, "MaaWlRootsControllerCreate"},
+	{&MaaKWinControllerCreate, "MaaKWinControllerCreate"},
 	{&MaaCustomControllerCreate, "MaaCustomControllerCreate"},
 	{&MaaGamepadControllerCreate, "MaaGamepadControllerCreate"},
 	{&MaaMacOSControllerCreate, "MaaMacOSControllerCreate"},


### PR DESCRIPTION
添加kwin控制器相关

## 由 Sourcery 提供的摘要

为兼容 KWin 的 Wayland 环境添加一个新的控制器实现，并通过框架绑定暴露其原生构造函数。

新功能：
- 引入 `NewKWinController`，用于在支持 XDG Screencast Portal 和 `uinput` 的 Wayland 组合器上创建控制器。

改进：
- 扩展原生框架绑定以包含 `MaaKWinControllerCreate`，并将其注册到框架入口列表中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new controller implementation for KWin-compatible Wayland environments and expose its native constructor through the framework bindings.

New Features:
- Introduce NewKWinController for creating controllers on Wayland compositors supporting the XDG Screencast Portal and uinput.

Enhancements:
- Extend native framework bindings to include MaaKWinControllerCreate and register it in the framework entry list.

</details>

新功能：
- 引入 `NewKWinController` 构造函数，用于创建面向 KWin Wayland 环境的控制器。

增强：
- 扩展原生框架绑定以暴露 `MaaKWinControllerCreate`，并将其注册到框架入口列表中。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

为兼容 KWin 的 Wayland 环境添加一个新的控制器实现，并通过框架绑定暴露其原生构造函数。

新功能：
- 引入 `NewKWinController`，用于在支持 XDG Screencast Portal 和 `uinput` 的 Wayland 组合器上创建控制器。

改进：
- 扩展原生框架绑定以包含 `MaaKWinControllerCreate`，并将其注册到框架入口列表中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new controller implementation for KWin-compatible Wayland environments and expose its native constructor through the framework bindings.

New Features:
- Introduce NewKWinController for creating controllers on Wayland compositors supporting the XDG Screencast Portal and uinput.

Enhancements:
- Extend native framework bindings to include MaaKWinControllerCreate and register it in the framework entry list.

</details>

</details>