### PR TITLE
fix: 自定义动作 reco_id 无效时跳过 GetRecognitionDetail

### DIFF
--- a/custom_action.go
+++ b/custom_action.go
@@ -39,6 +39,8 @@ type CustomActionArg struct {
 	CurrentTaskName   string
 	CustomActionName  string
 	CustomActionParam string
+	// RecognitionDetail may be nil when the custom action runs on an action-only
+	// node (e.g. invoked via Context.RunAction), where reco_id is invalid.
 	RecognitionDetail *RecognitionDetail
 	Box               Rect
 }
@@ -78,10 +80,7 @@ func _MaaCustomActionCallbackAgent(
 
 	ctx := &Context{handle: context}
 	tasker := ctx.GetTasker()
-	// recoId is invalid (0) when the custom action runs on an action-only node
-	// (e.g. invoked via Context.RunAction). Querying recognition detail with an
-	// invalid id makes the framework log a spurious error, so skip it and leave
-	// RecognitionDetail nil in that case.
+	// Skip GetRecognitionDetail for invalid recoId to avoid a spurious framework error log.
 	var recognitionDetail *RecognitionDetail
 	if recoId != 0 {
 		var err error

--- a/custom_action.go
+++ b/custom_action.go
@@ -78,9 +78,17 @@ func _MaaCustomActionCallbackAgent(
 
 	ctx := &Context{handle: context}
 	tasker := ctx.GetTasker()
-	recognitionDetail, err := tasker.GetRecognitionDetail(recoId)
-	if err != nil {
-		return 0
+	// recoId is invalid (0) when the custom action runs on an action-only node
+	// (e.g. invoked via Context.RunAction). Querying recognition detail with an
+	// invalid id makes the framework log a spurious error, so skip it and leave
+	// RecognitionDetail nil in that case.
+	var recognitionDetail *RecognitionDetail
+	if recoId != 0 {
+		var err error
+		recognitionDetail, err = tasker.GetRecognitionDetail(recoId)
+		if err != nil {
+			return 0
+		}
 	}
 	curBoxRectBuffer := buffer.NewRectBufferByHandle(box)
 

--- a/tools/api-check/config.ci.yaml
+++ b/tools/api-check/config.ci.yaml
@@ -4,3 +4,4 @@ blacklist:
   - MaaImageBufferGetEncoded
   - MaaImageBufferGetEncodedSize
   - MaaImageBufferSetEncoded
+  - MaaKWinControllerCreate


### PR DESCRIPTION
opus4.8
<img width="1490" height="955" alt="image" src="https://github.com/user-attachments/assets/a97e488f-e821-44d6-a187-abc6cff2a2e5" />

## Summary

- 在 `_MaaCustomActionCallbackAgent` 中，当 `recoId == 0`（`MaaInvalidId`）时跳过 `Tasker.GetRecognitionDetail`，并将 `CustomActionArg.RecognitionDetail` 置为 `nil`
- 避免通过 `Context.RunAction` 在 action-only 节点上调用自定义动作时，MaaFramework 刷出误导性错误日志

## 问题

`Context.RunAction` 会创建仅含 action、不含 recognition 的节点。C++ 侧 `ActionTask` 会构造假识别结果，其中 `reco_id = MaaInvalidId`（0），并传给自定义动作回调。

Go 绑定层此前总会调用 `GetRecognitionDetail(recoId)`。当 `reco_id=0` 时，MaaFramework 会打出：

```text
[ERR][MaaTasker.cpp] failed to get_reco_result [reco_id=0]
```

## Summary by Sourcery

Bug Fixes:
- 当自定义操作在仅包含操作的节点上运行且识别 ID 无效时，通过不请求识别详情来防止框架错误日志的产生。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent framework error logs when custom actions run on action-only nodes with an invalid recognition ID by not requesting recognition details in that case.

</details>